### PR TITLE
Upgrade and Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 !/.gitignore
 
 target/
+/bin/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ result.
 
 Relevant resources:
 
-http://docs.spring.io/spring-batch/3.0.x/reference/html/springBatchIntegration.html
+https://docs.spring.io/spring-batch/docs/4.3.8/reference/html/spring-batch-integration.html
 
-http://docs.spring.io/spring-integration/docs/4.3.10.RELEASE/reference/html/
+http://docs.spring.io/spring-integration/docs/5.5.18/reference/html/
 
 https://github.com/spring-projects/spring-integration-java-dsl/wiki/spring-integration-java-dsl-reference
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.4.RELEASE</version>
+		<version>2.7.12</version>
 	</parent>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/java/net/oldgeek/BatchConfig.java
+++ b/src/main/java/net/oldgeek/BatchConfig.java
@@ -29,7 +29,7 @@ public class BatchConfig {
 	Step sampleStep() {
 		return stepBuilderFactory.get("sampleStep")//
 				.<String, String>chunk(5) //
-				.reader(itemReader(null)) //
+				.reader(itemReader(null)) // null will be replaced by #{jobParameters[file_path]}
 				.writer(i -> i.stream().forEach(j -> System.out.println(j))) //
 				.build();
 	}

--- a/src/main/java/net/oldgeek/FileMessageToJobRequest.java
+++ b/src/main/java/net/oldgeek/FileMessageToJobRequest.java
@@ -24,14 +24,16 @@ public class FileMessageToJobRequest {
 		this.job = job;
 	}
 
-	@Transformer
+	@Transformer// inputChannel and outputChannel setup in sampleFlow Bean (check IntegrationConfig.class)
 	public JobLaunchRequest toRequest(Message<File> message) {
 		JobParametersBuilder jobParametersBuilder = new JobParametersBuilder();
 
 		jobParametersBuilder.addString(fileParameterName, message.getPayload().getAbsolutePath());
-		// We add a dummy value to make job params unique, or else spring batch
+		// TODO: I do not know hot fix this yet, but not supposed to 
+		// have to add a dummy value to make job params unique, or else spring batch
 		// will only run it the first time
-		jobParametersBuilder.addDate("dummy", new Date());
+		// Suppose there must be some default we need to change to allow multiple jobs executions with the same parameters
+		jobParametersBuilder.addDate("timestamp", new Date());
 
 		return new JobLaunchRequest(job, jobParametersBuilder.toJobParameters());
 	}

--- a/src/main/java/net/oldgeek/IntegrationConfig.java
+++ b/src/main/java/net/oldgeek/IntegrationConfig.java
@@ -12,7 +12,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
-import org.springframework.integration.dsl.core.Pollers;
+import org.springframework.integration.dsl.Pollers; // newer Spring Batch versions
 import org.springframework.integration.file.FileReadingMessageSource;
 import org.springframework.integration.file.FileReadingMessageSource.WatchEventType;
 import org.springframework.integration.file.filters.SimplePatternFileListFilter;
@@ -29,6 +29,10 @@ public class IntegrationConfig {
 	protected DirectChannel inputChannel() {
 		return new DirectChannel();
 	}
+	
+	protected DirectChannel outputChannel() {
+		return new DirectChannel();
+	}
 
 	@Bean
 	public IntegrationFlow sampleFlow() {
@@ -37,6 +41,7 @@ public class IntegrationConfig {
 				.from(fileReadingMessageSource(), c -> c.poller(Pollers.fixedDelay(5000)))//
 				.channel(inputChannel()) //
 				.transform(fileMessageToJobRequest()) //
+				.channel(outputChannel())
 				.handle(jobLaunchingMessageHandler()) //
 				.handle(jobExecution -> {
 					System.out.println(jobExecution.getPayload());

--- a/src/main/java/net/oldgeek/Main.java
+++ b/src/main/java/net/oldgeek/Main.java
@@ -1,5 +1,6 @@
 package net.oldgeek;
 
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.integration.annotation.IntegrationComponentScan;
@@ -10,7 +11,7 @@ public class Main {
 
 	public static void main(String[] args) {
 		new SpringApplicationBuilder(Main.class)//
-				.web(false)//
+				.web(WebApplicationType.NONE)// newer Spring versions
 				.run(args);
 	}
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,10 @@
 logging.level.net.oldgeek: DEBUG
 
-spring.datasource.url=jdbc:h2:~/test
-spring.datasource.username=sa
-spring.datasource.password=
-spring.datasource.driver-class-name=org.h2.Driver
+#trust Spring Boot (and avoid errors when minor assumptions change)
+#spring.datasource.url=jdbc:h2:~/test
+#spring.datasource.username=sa
+#spring.datasource.password=
+#spring.datasource.driver-class-name=org.h2.Driver
 
 # Prevent jobs to be executed at startup
 spring.batch.job.enabled=false

--- a/src/test/java/net/oldgeek/BatchTests.java
+++ b/src/test/java/net/oldgeek/BatchTests.java
@@ -1,9 +1,9 @@
 package net.oldgeek;
 
-import java.util.Date;
-
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.JobExecution;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.test.JobLauncherTestUtils;
@@ -24,10 +24,9 @@ public class BatchTests {
 	public void testSampleJob() throws Exception {
 		JobParametersBuilder jobParametersBuilder = new JobParametersBuilder();
 		jobParametersBuilder.addString("file_path", "src/test/resources/sample.txt");
-		// We add a dummy value to make job params unique, or else spring batch
-		// will only run it the first time
-		jobParametersBuilder.addDate("dummy", new Date());
+
 		JobExecution jobExecution = jobLauncherTestUtils.launchJob(jobParametersBuilder.toJobParameters());
 		System.out.println(jobExecution.getExitStatus());
+		assertEquals(jobExecution.getExitStatus(), ExitStatus.COMPLETED);
 	}
 }


### PR DESCRIPTION
Updated Spring Boot Starter from 1.5.4 to 2.7.12.

README update to match new Spring Batch Integration and Spring Integration versions.

Fix spring auto configured datasource issue that was causing error.

Added missing outputchannel that was causing error.

Added several code comments.

Tested and it run in JRE 17.